### PR TITLE
fix: ダークモードの設定を削除し、ライトモードと同じUIが表示されるように修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,12 +12,13 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+/* ダークモードの無効化 */
+/* @media (prefers-color-scheme: dark) { */
+/*   :root { */
+/*     --background: #0a0a0a; */
+/*     --foreground: #ededed; */
+/*   } */
+/* } */
 
 body {
   background: var(--background);


### PR DESCRIPTION
# 概要

背景色にwhiteを指定していたため、ダークモードでSnippetCardの文字が見えなくなる不具合があった。なので修正した。

## スクリーンショット

<!-- UIを変更した場合、適宜必要と思われる場合に書いておく -->

# 詳細

# 動作確認

- [ ] ライトモード、ダークモードでUIをチェック
- [ ] ウィンドウサイズを変えたり、スマホサイズでもUIが崩れないかチェック
<!-- 必要な動作確認項目を追加で記載 -->
