### PR TITLE
fix: solition problem make frequent requests to ws

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -7,6 +7,12 @@ interface UseWebSocketOptions {
 
 export const useWebSocket = ({ url, onMessage }: UseWebSocketOptions) => {
 	const ws = useRef<WebSocket | null>(null);
+	const onMessageRef = useRef(onMessage);
+
+	// Keep the latest onMessage callback in ref
+	useEffect(() => {
+		onMessageRef.current = onMessage;
+	}, [onMessage]);
 
 	useEffect(() => {
 		ws.current = new WebSocket(url);
@@ -18,7 +24,7 @@ export const useWebSocket = ({ url, onMessage }: UseWebSocketOptions) => {
 		ws.current.onmessage = (event) => {
 			try {
 				const data = JSON.parse(event.data);
-				onMessage(data);
+				onMessageRef.current(data); // Use ref to always get the latest callback
 			} catch (error) {
 				console.error("Failed to parse WebSocket message:", error);
 			}
@@ -35,7 +41,7 @@ export const useWebSocket = ({ url, onMessage }: UseWebSocketOptions) => {
 		return () => {
 			ws.current?.close();
 		};
-	}, [url, onMessage]);
+	}, [url]); // Removed onMessage from dependencies
 
 	const sendMessage = (data: any) => {
 		if (ws.current && ws.current.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
# 概要
再レンダリング時に再接続を行ってしまうことに起因するconnectionIdの損失を防いでいます
# 詳細
### **📌 元々の問題**

**症状**: 画面上で何かをタップするたびにWebSocketが切断→再接続を繰り返す

- コンソールに「WebSocket Disconnected」→「WebSocket Connected」が連続で表示される
- 接続のたびにconnectionIdが変わってしまう
- サーバー側でconnectionIdベースの処理ができなくなる

### **🔍 根本原因**

**問題のコード** (

useWebSocket.ts):

```
typescript

useEffect(() => {
    ws.current = new WebSocket(url);
    ws.current.onmessage = (event) => {
        onMessage(data);// ← ここで直接onMessageを使用
    };
return () => { ws.current?.close(); };
}, [url, onMessage]);// ← onMessageが依存配列に含まれている

```

**なぜ問題だったのか**:

1. page.tsxで毎回新しいアロー関数を作成:
    
    ```
    typescript
    
    const { sendMessage } = useWebSocket({
        onMessage: (data) => { setNotification(data); },// 毎回新しい関数
    });
    
    ```
    
2. コンポーネントが再レンダリングされるたび（タップ、状態変更など）に:
    - 新しい**onMessage**関数が生成される
    - **`useEffect`**の依存配列が変更を検知
    - クリーンアップ関数でWebSocketを切断
    - 新しいWebSocket接続を作成
3. **再レンダリングのトリガー**:
    - ボタンタップ →  → 再レンダリング
        
        ```
        setIsFormVisible(true)
        ```
        
    - 通知表示 →  → 再レンダリング
        
        ```
        setNotification(data)
        ```
        
    - フォーム閉じる →  → 再レンダリング
        
        ```
        setIsFormVisible(false)
        ```
        

### **✅ 解決方法**

```
useRef
```

**を使って最新のコールバックへの参照を保持**

:

```
typescript

const onMessageRef = useRef(onMessage);

// 最新のonMessageをrefに保存（再レンダリング時に更新）
useEffect(() => {
    onMessageRef.current = onMessage;
}, [onMessage]);

useEffect(() => {
    ws.current = new WebSocket(url);
    ws.current.onmessage = (event) => {
        onMessageRef.current(data);// refを使用（安定した参照）
    };
return () => { ws.current?.close(); };
}, [url]);// onMessageを依存配列から削除！

```

**重要なポイント**:

- **`useRef`**は再レンダリング間で安定した参照を保持
- **`onMessageRef.current`**は常に最新のコールバックを指す
- **`useEffect`**の依存配列に**onMessage**が不要になる
- WebSocket接続はが変わるときだけ再作成される
    
    ```
    url
    ```
    

### **🎯 実装後の動作**

**修正前**:

```

タップ → 再レンダリング → WebSocket切断 → 再接続 → connectionId変更

```

**修正後**:

```

タップ → 再レンダリング → WebSocket接続維持 → connectionId維持

```

### **💡 苦戦したポイント**

1. **初見では気づきにくい**: コードを見ても一見正常に見える
2. **React特有の問題**: 関数が毎回新しく生成される仕様を理解する必要がある
3. **依存配列の最適化**: の依存配列管理は慎重に行う必要がある
    
    ```
    useEffect
    ```
    
4. **デバッグの難しさ**: 接続は成功するので、再接続が頻繁に起きていることに気づきにくい

### **📊 他の解決策（参考）**

今回採用しなかった代替案:

**解決策A**: 呼び出し側で

```
useCallback
```

を使う

```
typescript

const onMessage = useCallback((data) => {
    setNotification(data);
}, []);

```

→ **欠点**:

useWebSocketを使う全ての場所で対応が必要

**解決策B**:

```
url
```

も

```
useMemo
```

で固定

```
typescript

const url = useMemo(() => "wss://...", []);

```

→ **欠点**: urlが動的に変わる場合に対応できない

**今回の解決策が最適な理由**:

- フック内部で完結（利用側の変更不要）
- 他の箇所で**useWebSocket**を使っていても自動的に修正される
- 最新のコールバックを常に使用できる
# 動作確認

- [ ] ライトモード、ダークモードでUIをチェック
- [ ] ウィンドウサイズを変えたり、スマホサイズでもUIが崩れないかチェック
<!-- 必要な動作確認項目を追加で記載 -->
